### PR TITLE
Update gamescope to 3.13.3 and disable checker for stb

### DIFF
--- a/modules/wlroots.yml
+++ b/modules/wlroots.yml
@@ -23,8 +23,8 @@ modules:
       - --datarootdir=${FLATPAK_DEST}/lib/
     sources:
       - type: archive
-        url: https://github.com/vcrhonek/hwdata/archive/refs/tags/v0.374.tar.gz
-        sha256: 2a0988bf5e97e49159d7f02a5e02a719c8976d4ec883a8abb635149d221ceca0
+        url: https://github.com/vcrhonek/hwdata/archive/refs/tags/v0.376.tar.gz
+        sha256: 48d85dbf05650b2c382ffaadeb601cac1650f5a34ee5c452df8021af988ea090
         x-checker-data:
           type: anitya
           project-id: 13577

--- a/modules/xwayland.yml
+++ b/modules/xwayland.yml
@@ -4,8 +4,8 @@ config-opts:
   - -Dsecure-rpc=false
 sources:
   - type: archive
-    url: https://xorg.freedesktop.org/archive/individual/xserver/xwayland-23.2.0.tar.xz
-    sha256: 7f33ec2a34de6e66ae1b7e44872c3a2146192872c719b9acf192814edbabd4c5
+    url: https://xorg.freedesktop.org/archive/individual/xserver/xwayland-23.2.2.tar.xz
+    sha256: 9f7c0938d2a41e941ffa04f99c35e5db2bcd3eec034afe8d35d5c810a22eb0a8
     x-checker-data:
       type: anitya
       project-id: 180949

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.metainfo.xml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.metainfo.xml
@@ -9,6 +9,7 @@
   <project_license>BSD-2-Clause</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
+    <release version="3.13.3" date="2023-11-15"/>
     <release version="3.12.5" date="2023-09-12"/>
     <release version="3.12.3" date="2023-08-17"/>
     <release version="3.12.2" date="2023-08-16"/>

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.yml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.yml
@@ -59,6 +59,8 @@ modules:
           - type: archive
             url: https://github.com/nothings/stb/archive/5736b15f7ea0ffb08dd38af21067c314d6a3aae9/stb-5736b15f7ea0ffb08dd38af21067c314d6a3aae9.tar.gz
             sha256: d00921d49b06af62aa6bfb97c1b136bec661dd11dd4eecbcb0da1f6da7cedb4c
+            # The checker is disabled as gamescope uses stb_image_resize.h which is deprecated.
+            # If it starts depending on stb_image_resize2.h uncomment this.
             #x-checker-data:
             #  type: json
             #  url: https://api.github.com/repos/nothings/stb/commits?sha=master&per_page=1

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.yml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.yml
@@ -32,8 +32,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/ValveSoftware/gamescope.git
-        commit: a8471d81b36ea1d9dc90a7d35f9ad0631feaf1ae
-        tag: 3.12.5
+        commit: 31ad6917317e0cfaebb5088d9fa49833b7e0531c
+        tag: 3.13.3
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
@@ -59,13 +59,13 @@ modules:
           - type: archive
             url: https://github.com/nothings/stb/archive/5736b15f7ea0ffb08dd38af21067c314d6a3aae9/stb-5736b15f7ea0ffb08dd38af21067c314d6a3aae9.tar.gz
             sha256: d00921d49b06af62aa6bfb97c1b136bec661dd11dd4eecbcb0da1f6da7cedb4c
-            x-checker-data:
-              type: json
-              url: https://api.github.com/repos/nothings/stb/commits?sha=master&per_page=1
-              version-query: .[].sha
-              timestamp-query: .[].commit.committer.date
-              url-query: '"https://github.com/nothings/stb/archive/" + $version +
-                "/stb-" + $version + ".tar.gz"'
+            #x-checker-data:
+            #  type: json
+            #  url: https://api.github.com/repos/nothings/stb/commits?sha=master&per_page=1
+            #  version-query: .[].sha
+            #  timestamp-query: .[].commit.committer.date
+            #  url-query: '"https://github.com/nothings/stb/archive/" + $version +
+            #    "/stb-" + $version + ".tar.gz"'
         cleanup:
           - '*'
 


### PR DESCRIPTION
gamescope's `stb.wrap` fixes stb to before it removed `stb_image_resize.h`.
I guess at some gamescope will use `stb_image_resize2.h` and we can switch back on version tracking for stb.