### PR TITLE
Prepare for 24.08

### DIFF
--- a/modules/libei.yml
+++ b/modules/libei.yml
@@ -1,41 +1,97 @@
 name: libei
 buildsystem: meson
-build-options:
+build-options: &pythonpath
   env:
-    PYTHONPATH: /usr/lib/extensions/vulkan/gamescope/lib/python3.11/site-packages:/usr/lib/python3.11/site-packages
+    PYTHONPATH: /usr/lib/extensions/vulkan/gamescope/lib/python3.12/site-packages:/usr/lib/python3.12/site-packages
 config-opts:
   - -Dtests=disabled
   - -Dliboeffis=disabled
 sources:
   - type: archive
-    url: https://gitlab.freedesktop.org/libinput/libei/-/archive/1.2.1/libei-1.2.1.tar.gz
-    sha256: 7e06f06aa4dd1f7d170a0e5194644fe5cc889adc9b7be16bed5f2c39145569a4
+    url: https://gitlab.freedesktop.org/libinput/libei/-/archive/1.3.0/libei-1.3.0.tar.gz
+    sha256: 162dc7b0d86a4575cdde1d3cb04f364f89a8b1ba6d95fe0b442564e0444d851d
     x-checker-data:
       type: anitya
       project-id: 350087
       url-template: https://gitlab.freedesktop.org/libinput/libei/-/archive/$version/libei-$version.tar.gz
 modules:
-  - name: python3-attrs
+  - name: python3-Jinja2-attrs
+    build-options: *pythonpath
     buildsystem: simple
     build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "attrs" --no-build-isolation
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} --no-build-isolation trove_classifiers
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} --no-build-isolation pluggy
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} --no-build-isolation flit-core
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} --no-build-isolation pathspec
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} --no-build-isolation hatchling
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} --no-build-isolation hatch-fancy-pypi-readme
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} --no-build-isolation attrs
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} --no-build-isolation Jinja2
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl
-        sha256: 99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1
-    cleanup:
-      - /lib/python*
-  - name: python3-Jinja2
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "Jinja2" --no-build-isolation
-    sources:
+        url: https://files.pythonhosted.org/packages/ed/55/39036716d19cab0747a5020fc7e907f362fbf48c984b14e62127f7e68e5d/jinja2-3.1.4.tar.gz
+        sha256: 4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369
+        x-checker-data:
+          type: pypi
+          name: Jinja2
       - type: file
-        url: https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl
-        sha256: 7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa
+        url: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
+        sha256: 44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
+        x-checker-data:
+          type: pypi
+          name: pluggy
+          packagetype: bdist_wheel
       - type: file
         url: https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz
         sha256: d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b
+        x-checker-data:
+          type: pypi
+          name: MarkupSafe
+      - type: file
+        url: https://files.pythonhosted.org/packages/c4/e6/c1ac50fe3eebb38a155155711e6e864e254ce4b6e17fe2429b4c4d5b9e80/flit_core-3.9.0.tar.gz
+        sha256: 72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba
+        x-checker-data:
+          type: pypi
+          name: flit-core
+      - type: file
+        url: https://files.pythonhosted.org/packages/fc/0f/aafca9af9315aee06a89ffde799a10a582fe8de76c563ee80bbcdc08b3fb/attrs-24.2.0.tar.gz
+        sha256: 5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346
+        x-checker-data:
+          type: pypi
+          name: attrs
+      - type: file
+        url: https://files.pythonhosted.org/packages/a3/51/8a4a67a8174ce59cf49e816e38e9502900aea9b4af672d0127df8e10d3b0/hatchling-1.25.0.tar.gz
+        sha256: 7064631a512610b52250a4d3ff1bd81551d6d1431c4eb7b72e734df6c74f4262
+        x-checker-data:
+          type: pypi
+          name: hatchling
+      - type: file
+        url: https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz
+        sha256: a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712
+        x-checker-data:
+          type: pypi
+          name: pathspec
+      - type: file
+        url: https://files.pythonhosted.org/packages/0f/b0/09794439a62a7dc18bffdbf145aaf50297fd994890b11da27a13e376b947/trove_classifiers-2024.7.2-py3-none-any.whl
+        sha256: ccc57a33717644df4daca018e7ec3ef57a835c48e96a1e71fc07eb7edac67af6
+        x-checker-data:
+          type: pypi
+          name: trove_classifiers
+          packagetype: bdist_wheel
+      - type: file
+        url: https://files.pythonhosted.org/packages/b4/c2/c9094283a07dd96c5a8f7a5f1910259d40d2e29223b95dd875a6ca13b58f/hatch_fancy_pypi_readme-24.1.0.tar.gz
+        sha256: 44dd239f1a779b9dcf8ebc9401a611fd7f7e3e14578dcf22c265dfaf7c1514b8
+        x-checker-data:
+          type: pypi
+          name: hatch-fancy-pypi-readme
     cleanup:
       - /lib/python*
 cleanup:

--- a/modules/libevdev.yml
+++ b/modules/libevdev.yml
@@ -5,13 +5,13 @@ config-opts:
   - -Ddocumentation=disabled
 sources:
   - type: archive
-    url: https://freedesktop.org/software/libevdev/libevdev-1.13.2.tar.xz
+    url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.2.tar.xz
     sha256: 3eca86a6ce55b81d5bce910637fc451c8bbe373b1f9698f375c7f1ad0de3ac48
     x-checker-data:
       type: anitya
       project-id: 20540
       stable-only: true
-      url-template: https://freedesktop.org/software/libevdev/libevdev-$version.tar.xz
+      url-template: https://www.freedesktop.org/software/libevdev/libevdev-$version.tar.xz
 cleanup:
   - /bin
   - /include

--- a/modules/libinput.yml
+++ b/modules/libinput.yml
@@ -9,8 +9,8 @@ config-opts:
   - -Dzshcompletiondir=no
 sources:
   - type: archive
-    url: https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.26.1/libinput-1.26.1.tar.gz
-    sha256: 84fdd16ba0bd3a9adf6c1ffe4292b7a644b0d70f57f81f8239fd499a801189fb
+    url: https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.26.2/libinput-1.26.2.tar.gz
+    sha256: 5c1c4150f217fea1db2d1fd88e2607b2f1928cfde65c34da65a9f24dcfd69464
     x-checker-data:
       type: anitya
       project-id: 5781

--- a/modules/xwayland.yml
+++ b/modules/xwayland.yml
@@ -4,8 +4,8 @@ config-opts:
   - -Dsecure-rpc=false
 sources:
   - type: archive
-    url: https://xorg.freedesktop.org/archive/individual/xserver/xwayland-24.1.1.tar.xz
-    sha256: 7125bee0b10335805d7f5ba57dfaa359a7850af1a68524f1d97b362741a51832
+    url: https://xorg.freedesktop.org/archive/individual/xserver/xwayland-24.1.2.tar.xz
+    sha256: 141eb76e7e422a3661c08782c70be40931084755042c04506e0d97dd463ef7d2
     x-checker-data:
       type: anitya
       project-id: 180949
@@ -71,8 +71,8 @@ modules:
       - --disable-static
     sources:
       - type: archive
-        url: https://xorg.freedesktop.org/releases/individual/lib/libXfont2-2.0.6.tar.xz
-        sha256: 74ca20017eb0fb3f56d8d5e60685f560fc85e5ff3d84c61c4cb891e40c27aef4
+        url: https://xorg.freedesktop.org/releases/individual/lib/libXfont2-2.0.7.tar.xz
+        sha256: 8b7b82fdeba48769b69433e8e3fbb984a5f6bf368b0d5f47abeec49de3e58efb
         x-checker-data:
           type: anitya
           project-id: 17165

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.metainfo.xml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.metainfo.xml
@@ -9,8 +9,11 @@
   <project_license>BSD-2-Clause</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
-    <release version="3.14.24" date="2024-07-10">
+    <release version="3.15.0" date="2024-08-20">
       <description></description>
+    </release>
+    <release version="3.14.24" date="2024-07-10">
+      <description/>
     </release>
     <release version="3.14.23" date="2024-07-05">
       <description/>

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.yml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.yml
@@ -1,7 +1,7 @@
 id: org.freedesktop.Platform.VulkanLayer.gamescope
-branch: '23.08'
+branch: 24.08beta
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: 24.08beta
 sdk: org.freedesktop.Sdk
 build-extension: true
 separate-locales: false
@@ -15,7 +15,7 @@ build-options:
   prepend-path: /usr/lib/extensions/vulkan/gamescope/bin
   prepend-ld-library-path: /usr/lib/extensions/vulkan/gamescope/lib
   prepend-pkg-config-path: /usr/lib/extensions/vulkan/gamescope/lib/pkgconfig
-  strip: true
+  #strip: true
 
 modules:
   - name: hwdata
@@ -23,8 +23,8 @@ modules:
       - --datarootdir=${FLATPAK_DEST}/share
     sources:
       - type: archive
-        url: https://github.com/vcrhonek/hwdata/archive/v0.384/hwdata-0.384.tar.gz
-        sha256: caa496a6203084ee3404c688a75ea05b4b10eec93340c503199647216127f347
+        url: https://github.com/vcrhonek/hwdata/archive/v0.385/hwdata-0.385.tar.gz
+        sha256: 577219d44d9686e8177f6291adbff7bacdd785ad4e8a8d0c4b2a14dbf850d6ac
         x-checker-data:
           type: anitya
           project-id: 13577
@@ -44,22 +44,6 @@ modules:
   - modules/xwayland.yml
   - modules/libei.yml
 
-  - name: libavif
-    buildsystem: cmake-ninja
-    sources:
-      - type: git
-        url: https://github.com/AOMediaCodec/libavif.git
-        tag: v1.0.4
-        commit: d77cfece0b3e233ee4bed49dfef1e7dc451599f8
-        x-checker-data:
-          type: anitya
-          project-id: 178015
-          tag-template: v$version
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - /lib/cmake
-
   - name: gamescope
     buildsystem: meson
     config-opts:
@@ -68,8 +52,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/ValveSoftware/gamescope.git
-        commit: cf2497fd7ec83f3d0dd5cb31b69540a2d129edad
-        tag: 3.14.24
+        commit: 250a14345faaa6e6b8331cf6979e3c54fe097023
+        tag: 3.15.0
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
@@ -80,6 +64,9 @@ modules:
         url: https://github.com/nothings/stb/archive/5736b15f7ea0ffb08dd38af21067c314d6a3aae9/stb.tar.gz
         sha256: d00921d49b06af62aa6bfb97c1b136bec661dd11dd4eecbcb0da1f6da7cedb4c
         dest: subprojects/stb
+      - type: git
+        url: https://git.linuxtv.org/edid-decode.git
+        dest: subprojects/edid-decode
 
       - type: shell
         commands:
@@ -151,8 +138,8 @@ modules:
           - -DCMAKE_CXX_FLAGS=
         sources:
           - type: archive
-            url: https://github.com/google/benchmark/archive/v1.8.4/benchmark-1.8.4.tar.gz
-            sha256: 3e7059b6b11fb1bbe28e33e02519398ca94c1818874ebed18e504dc6f709be45
+            url: https://github.com/google/benchmark/archive/v1.9.0/benchmark-1.9.0.tar.gz
+            sha256: 35a77f46cc782b16fac8d3b107fbfbb37dcd645f7c28eee19f3b8e0758b48994
             x-checker-data:
               type: anitya
               project-id: 229361


### PR DESCRIPTION
This is mostly to check if moving to 24.08 would fix the issue https://github.com/ValveSoftware/gamescope/issues/1445.
It doesn't fix it so I may revert to `3.14.24` when 24.08 is ready.

Other changes:
* Move to `24.08beta`
* Removes libavif and libwayland
* Add libliftoff edid-decode dep
* Fix libevdev url (SSL issues with freedesktop.org)
* Update libei python deps and add their new deps
* Stop stripping debug symbols?


hwdata: Update hwdata-0.384.tar.gz to 0.385
benchmark: Update benchmark-1.8.4.tar.gz to 1.9.0
gamescope: Update gamescope.git to 3.15.0
libinput: Update libinput-1.26.1.tar.gz to 1.26.2
libxfont2: Update libXfont2-2.0.6.tar.xz to 2.0.7
xwayland: Update xwayland-24.1.1.tar.xz to 24.1.2
libei: Update libei-1.2.1.tar.gz to 1.3.0