### PR TITLE
Leave debug symbols intact

### DIFF
--- a/org.freedesktop.Platform.VulkanLayer.gamescope.yml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.yml
@@ -15,7 +15,6 @@ build-options:
   prepend-path: /usr/lib/extensions/vulkan/gamescope/bin
   prepend-ld-library-path: /usr/lib/extensions/vulkan/gamescope/lib
   prepend-pkg-config-path: /usr/lib/extensions/vulkan/gamescope/lib/pkgconfig
-  strip: true
 
 modules:
   - name: hwdata


### PR DESCRIPTION
Next few gamescope versions segfault.
Having debug symbols available really helps with debugging.