### PR TITLE
Update hwdata, libavif, benchmark and 4 more modules

### DIFF
--- a/modules/libei.yml
+++ b/modules/libei.yml
@@ -8,8 +8,8 @@ config-opts:
   - -Dliboeffis=disabled
 sources:
   - type: archive
-    url: https://gitlab.freedesktop.org/libinput/libei/-/archive/1.2.1/libei-1.2.1.tar.gz
-    sha256: 7e06f06aa4dd1f7d170a0e5194644fe5cc889adc9b7be16bed5f2c39145569a4
+    url: https://gitlab.freedesktop.org/libinput/libei/-/archive/1.3.0/libei-1.3.0.tar.gz
+    sha256: 162dc7b0d86a4575cdde1d3cb04f364f89a8b1ba6d95fe0b442564e0444d851d
     x-checker-data:
       type: anitya
       project-id: 350087
@@ -18,7 +18,8 @@ modules:
   - name: python3-attrs
     buildsystem: simple
     build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "attrs" --no-build-isolation
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} --no-build-isolation attrs
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl
@@ -28,7 +29,8 @@ modules:
   - name: python3-Jinja2
     buildsystem: simple
     build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "Jinja2" --no-build-isolation
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} --no-build-isolation Jinja2
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl

--- a/modules/libevdev.yml
+++ b/modules/libevdev.yml
@@ -5,13 +5,13 @@ config-opts:
   - -Ddocumentation=disabled
 sources:
   - type: archive
-    url: https://freedesktop.org/software/libevdev/libevdev-1.13.2.tar.xz
+    url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.2.tar.xz
     sha256: 3eca86a6ce55b81d5bce910637fc451c8bbe373b1f9698f375c7f1ad0de3ac48
     x-checker-data:
       type: anitya
       project-id: 20540
       stable-only: true
-      url-template: https://freedesktop.org/software/libevdev/libevdev-$version.tar.xz
+      url-template: https://www.freedesktop.org/software/libevdev/libevdev-$version.tar.xz
 cleanup:
   - /bin
   - /include

--- a/modules/libinput.yml
+++ b/modules/libinput.yml
@@ -9,8 +9,8 @@ config-opts:
   - -Dzshcompletiondir=no
 sources:
   - type: archive
-    url: https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.26.1/libinput-1.26.1.tar.gz
-    sha256: 84fdd16ba0bd3a9adf6c1ffe4292b7a644b0d70f57f81f8239fd499a801189fb
+    url: https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.26.2/libinput-1.26.2.tar.gz
+    sha256: 5c1c4150f217fea1db2d1fd88e2607b2f1928cfde65c34da65a9f24dcfd69464
     x-checker-data:
       type: anitya
       project-id: 5781

--- a/modules/xwayland.yml
+++ b/modules/xwayland.yml
@@ -4,8 +4,8 @@ config-opts:
   - -Dsecure-rpc=false
 sources:
   - type: archive
-    url: https://xorg.freedesktop.org/archive/individual/xserver/xwayland-24.1.1.tar.xz
-    sha256: 7125bee0b10335805d7f5ba57dfaa359a7850af1a68524f1d97b362741a51832
+    url: https://xorg.freedesktop.org/archive/individual/xserver/xwayland-24.1.2.tar.xz
+    sha256: 141eb76e7e422a3661c08782c70be40931084755042c04506e0d97dd463ef7d2
     x-checker-data:
       type: anitya
       project-id: 180949
@@ -71,8 +71,8 @@ modules:
       - --disable-static
     sources:
       - type: archive
-        url: https://xorg.freedesktop.org/releases/individual/lib/libXfont2-2.0.6.tar.xz
-        sha256: 74ca20017eb0fb3f56d8d5e60685f560fc85e5ff3d84c61c4cb891e40c27aef4
+        url: https://xorg.freedesktop.org/releases/individual/lib/libXfont2-2.0.7.tar.xz
+        sha256: 8b7b82fdeba48769b69433e8e3fbb984a5f6bf368b0d5f47abeec49de3e58efb
         x-checker-data:
           type: anitya
           project-id: 17165

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.yml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.yml
@@ -22,8 +22,8 @@ modules:
       - --datarootdir=${FLATPAK_DEST}/share
     sources:
       - type: archive
-        url: https://github.com/vcrhonek/hwdata/archive/v0.384/hwdata-0.384.tar.gz
-        sha256: caa496a6203084ee3404c688a75ea05b4b10eec93340c503199647216127f347
+        url: https://github.com/vcrhonek/hwdata/archive/v0.385/hwdata-0.385.tar.gz
+        sha256: 577219d44d9686e8177f6291adbff7bacdd785ad4e8a8d0c4b2a14dbf850d6ac
         x-checker-data:
           type: anitya
           project-id: 13577
@@ -45,11 +45,13 @@ modules:
 
   - name: libavif
     buildsystem: cmake-ninja
+    config-opts:
+      - -DAVIF_LIBYUV=OFF
     sources:
       - type: git
         url: https://github.com/AOMediaCodec/libavif.git
-        tag: v1.0.4
-        commit: d77cfece0b3e233ee4bed49dfef1e7dc451599f8
+        tag: v1.1.1
+        commit: bb24db03cd99befe09c87b602e36f24d75a980d1
         x-checker-data:
           type: anitya
           project-id: 178015
@@ -150,8 +152,8 @@ modules:
           - -DCMAKE_CXX_FLAGS=
         sources:
           - type: archive
-            url: https://github.com/google/benchmark/archive/v1.8.4/benchmark-1.8.4.tar.gz
-            sha256: 3e7059b6b11fb1bbe28e33e02519398ca94c1818874ebed18e504dc6f709be45
+            url: https://github.com/google/benchmark/archive/v1.9.0/benchmark-1.9.0.tar.gz
+            sha256: 35a77f46cc782b16fac8d3b107fbfbb37dcd645f7c28eee19f3b8e0758b48994
             x-checker-data:
               type: anitya
               project-id: 229361


### PR DESCRIPTION
Update dependencies, fix libei url

hwdata: Update hwdata-0.384.tar.gz to 0.385
libavif: Update libavif.git to 1.1.1
benchmark: Update benchmark-1.8.4.tar.gz to 1.9.0
libinput: Update libinput-1.26.1.tar.gz to 1.26.2
libxfont2: Update libXfont2-2.0.6.tar.xz to 2.0.7
xwayland: Update xwayland-24.1.1.tar.xz to 24.1.2
libei: Update libei-1.2.1.tar.gz to 1.3.0