### PR TITLE
Update hwdata, gamescope, libinput, xwayland, libei and luajit modules

### DIFF
--- a/modules/libei.yml
+++ b/modules/libei.yml
@@ -8,8 +8,8 @@ config-opts:
   - -Dliboeffis=disabled
 sources:
   - type: archive
-    url: https://gitlab.freedesktop.org/libinput/libei/-/archive/1.3.0/libei-1.3.0.tar.gz
-    sha256: 162dc7b0d86a4575cdde1d3cb04f364f89a8b1ba6d95fe0b442564e0444d851d
+    url: https://gitlab.freedesktop.org/libinput/libei/-/archive/1.4.0/libei-1.4.0.tar.gz
+    sha256: f09b21d014a892daf2916026b73a06988180c7c6e696bfd952583cd013d6aaed
     x-checker-data:
       type: anitya
       project-id: 350087

--- a/modules/libinput.yml
+++ b/modules/libinput.yml
@@ -9,8 +9,8 @@ config-opts:
   - -Dzshcompletiondir=no
 sources:
   - type: archive
-    url: https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.27.0/libinput-1.27.0.tar.gz
-    sha256: b11b900bf88ef68fe688c107226bb453ef26faf461ae2dcf9690b00009d660a6
+    url: https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.27.1/libinput-1.27.1.tar.gz
+    sha256: f6d623dd8230db337a6457645ebca96b9d4788a56385463bb14b8174910dfe23
     x-checker-data:
       type: anitya
       project-id: 5781

--- a/modules/xwayland.yml
+++ b/modules/xwayland.yml
@@ -4,8 +4,8 @@ config-opts:
   - -Dsecure-rpc=false
 sources:
   - type: archive
-    url: https://xorg.freedesktop.org/archive/individual/xserver/xwayland-24.1.4.tar.xz
-    sha256: d96a78dbab819f55750173444444995b5031ebdcc15b77afebbd8dbc02af34f4
+    url: https://xorg.freedesktop.org/archive/individual/xserver/xwayland-24.1.6.tar.xz
+    sha256: 737e612ca36bbdf415a911644eb7592cf9389846847b47fa46dc705bd754d2d7
     x-checker-data:
       type: anitya
       project-id: 180949

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.metainfo.xml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.metainfo.xml
@@ -9,8 +9,11 @@
   <project_license>BSD-2-Clause</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
-    <release version="3.16.1" date="2024-12-18">
+    <release version="3.16.2" date="2025-03-02">
       <description></description>
+    </release>
+    <release version="3.16.1" date="2024-12-18">
+      <description/>
     </release>
     <release version="3.14.24" date="2024-07-10">
       <description/>

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.yml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.yml
@@ -22,8 +22,8 @@ modules:
       - --datarootdir=${FLATPAK_DEST}/share
     sources:
       - type: archive
-        url: https://github.com/vcrhonek/hwdata/archive/v0.390/hwdata-0.390.tar.gz
-        sha256: f10684093d2a7780de8a96d3dd8a2dd544ed6136dd359197750c42bb08ce526f
+        url: https://github.com/vcrhonek/hwdata/archive/v0.392/hwdata-0.392.tar.gz
+        sha256: 1f472d8f2ec824d4efe6a75480767c4ce240fa5d91b6428d9f8775035da3ba1f
         x-checker-data:
           type: anitya
           project-id: 13577
@@ -53,8 +53,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/ValveSoftware/gamescope.git
-        commit: 4da5e4a37560f9b3c85af2679330f9ec292c8ee1
-        tag: 3.16.1
+        commit: 2ccfa53b619d43d7a08f2457474f471552b7e6fb
+        tag: 3.16.2
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
hwdata: Update hwdata-0.390.tar.gz to 0.392
gamescope: Update gamescope.git to 3.16.2
libinput: Update libinput-1.27.0.tar.gz to 1.27.1
xwayland: Update xwayland-24.1.4.tar.xz to 24.1.6
libei: Update libei-1.3.0.tar.gz to 1.4.0
luajit: Update luajit2.git to 2.1-20250117