### PR TITLE
gamescope 3.16.7

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
-  "skip-icons-check": true
+  "skip-icons-check": true,
+  "require-important-update": true
 }
 

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.metainfo.xml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.metainfo.xml
@@ -9,8 +9,11 @@
   <project_license>BSD-2-Clause</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
-    <release version="3.16.4" date="2025-04-15">
+    <release version="3.16.7" date="2025-05-15">
       <description></description>
+    </release>
+    <release version="3.16.4" date="2025-04-15">
+      <description/>
     </release>
     <release version="3.16.3" date="2025-04-02">
       <description/>

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.yml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.yml
@@ -22,8 +22,8 @@ modules:
       - --datarootdir=${FLATPAK_DEST}/share
     sources:
       - type: archive
-        url: https://github.com/vcrhonek/hwdata/archive/v0.394/hwdata-0.394.tar.gz
-        sha256: b7c3fd7214a3b7c49d2661db127a712dc11cffd1799f793947aa1cb20aaf3298
+        url: https://github.com/vcrhonek/hwdata/archive/v0.395/hwdata-0.395.tar.gz
+        sha256: 1166f733c57afa82cfdad56e62ef044835fbc8c99ef65f033e6a5802716b5c66
         x-checker-data:
           type: anitya
           project-id: 13577
@@ -53,8 +53,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/ValveSoftware/gamescope.git
-        commit: 1ab8009d5dc5faaff5d890ef896483ef14363536
-        tag: 3.16.4
+        commit: baae74c4b13676fa76a8b200f21ac78f55079734
+        tag: 3.16.7
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
@@ -136,8 +136,8 @@ modules:
           - -DCMAKE_CXX_FLAGS=
         sources:
           - type: archive
-            url: https://github.com/google/benchmark/archive/v1.9.2/benchmark-1.9.2.tar.gz
-            sha256: 409075176168dc46bbb81b74c1b4b6900385b5d16bfc181d678afb060d928bd3
+            url: https://github.com/google/benchmark/archive/v1.9.3/benchmark-1.9.3.tar.gz
+            sha256: b94263b018042007eb53f79639f21ae47800808c73cf1b7df85622b6e2b1aa32
             x-checker-data:
               type: anitya
               project-id: 229361

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.yml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.yml
@@ -65,10 +65,34 @@ modules:
         url: https://github.com/nothings/stb/archive/5736b15f7ea0ffb08dd38af21067c314d6a3aae9/stb.tar.gz
         sha256: d00921d49b06af62aa6bfb97c1b136bec661dd11dd4eecbcb0da1f6da7cedb4c
         dest: subprojects/stb
+        # Tracking based on may cause spurious MR before gamescope release
+        x-checker-data:
+          type: html
+          url: https://raw.githubusercontent.com/ValveSoftware/gamescope/refs/heads/master/subprojects/stb.wrap
+          version-pattern: revision\s*=\s*([a-f0-9]+)
+          url-template: https://github.com/nothings/stb/archive/$version/stb.tar.gz
+
+
+      # Keep glm tracking https://github.com/ValveSoftware/gamescope/blob/master/subprojects/glm.wrap
+      - type: archive
+        url: https://github.com/g-truc/glm/archive/0af55ccecd98d4e5a8d1fad7de25ba429d60e863/glm.tar.gz
+        sha256: e7f187d83523f505eb38dd25d297ea6c0d4ed856d733e808f18253f5a8fa88a0
+        dest: subprojects/glm
+        x-checker-data:
+          type: html
+          url: https://raw.githubusercontent.com/ValveSoftware/gamescope/refs/heads/master/subprojects/glm.wrap
+          version-pattern: revision\s*=\s*([a-f0-9]+)
+          url-template: https://github.com/g-truc/glm/archive/$version/glm.tar.gz
 
       - type: shell
         commands:
-          - install -Dm644 subprojects/packagefiles/stb/meson.build -t subprojects/stb
+          # Abort build if gamescope wrap file change
+          - echo -n 'Checking stb version ' && grep 5736b15f7ea0ffb08dd38af21067c314d6a3aae9
+            subprojects/stb.wrap
+          - echo -n 'Checking glm version ' && grep 0af55ccecd98d4e5a8d1fad7de25ba429d60e863
+            subprojects/glm.wrap
+          # As we download subprojects outside of meson we must apply gamescopes packagefiles (add meson.build to them)
+          - meson subprojects packagefiles --apply
 
     cleanup:
       - /include
@@ -80,38 +104,6 @@ modules:
     post-install:
       - mv ${FLATPAK_DEST}/bin/gamescope ${FLATPAK_DEST}/bin/gamescope-brokey
     modules:
-      - name: glm
-        buildsystem: cmake-ninja
-        no-make-install: true
-        post-install:
-          - install -d ${FLATPAK_DEST}/include
-          - cp -R glm ${FLATPAK_DEST}/include
-          - cp -R cmake ${FLATPAK_DEST}/lib/cmake
-          - cp glm.pc.in ${FLATPAK_DEST}/lib/pkgconfig/glm.pc
-        sources:
-          - type: archive
-            url: https://github.com/g-truc/glm/archive/1.0.1/glm-1.0.1.tar.gz
-            sha256: 9f3174561fd26904b23f0db5e560971cbf9b3cbda0b280f04d5c379d03bf234c
-            x-checker-data:
-              type: json
-              url: https://api.github.com/repos/g-truc/glm/releases/latest
-              version-query: .tag_name
-              url-query: '"https://github.com/g-truc/glm/archive/" + $version + "/glm-"
-                + $version + ".tar.gz"'
-              # glm version 1.0.1 was causing multiple MRs to be opened during pre-release changes
-              # Maybe the initial pre-release was initially marked release and triggered the anitya record
-              #type: anitya
-              #project-id: 1181
-              #url-template: https://github.com/g-truc/glm/archive/$version/glm-$version.tar.gz
-          # Upstream hates packagers, so use a hack to make things work for us again.
-          # https://web.archive.org/web/20201214023324/https://github.com/g-truc/glm/pull/968
-          - type: file
-            path: glm.pc.in
-        cleanup:
-          - /include
-          - /lib/pkgconfig
-          - /lib/cmake
-
       - name: xmu
         sources:
           - type: archive


### PR DESCRIPTION
This enables `require-important-update` which currently should only trigger dependency updates when gamescope itself gets a release. I may tag more modules `is-important` at some point.

Use `meson subprojects packagefiles --apply` rather than manually copying `meson.build` files.

The glm wrap file now uses git rather than a tar ball.

Added checks to avoid pushing a build with dependencies that are out of sync with upstream.