### PR TITLE
Update seatd, hwdata and xmu

### DIFF
--- a/modules/libseat.yml
+++ b/modules/libseat.yml
@@ -9,8 +9,8 @@ config-opts:
   - -Dman-pages=disabled
 sources:
   - type: archive
-    url: https://git.sr.ht/~kennylevinsen/seatd/archive/0.9.1.tar.gz
-    sha256: 819979c922a0be258aed133d93920bce6a3d3565a60588d6d372ce9db2712cd3
+    url: https://git.sr.ht/~kennylevinsen/seatd/archive/0.9.2.tar.gz
+    sha256: 2811654fc87b3b1877f62e69cbf1e761c7072146f127860d9b8fe1ca27607d0e
     x-checker-data:
       type: anitya
       project-id: 234932

--- a/org.freedesktop.Platform.VulkanLayer.gamescope.yml
+++ b/org.freedesktop.Platform.VulkanLayer.gamescope.yml
@@ -22,8 +22,8 @@ modules:
       - --datarootdir=${FLATPAK_DEST}/share
     sources:
       - type: archive
-        url: https://github.com/vcrhonek/hwdata/archive/v0.402/hwdata-0.402.tar.gz
-        sha256: e390fe2f5f5ef7ed9ccbe62eb7cd40d4ee2b57389e7869c0dc96433c81812e7a
+        url: https://github.com/vcrhonek/hwdata/archive/v0.403/hwdata-0.403.tar.gz
+        sha256: 77d0a69e5558d16d33bbb510a09093deaf11c882baf9ef6ec5f18a8ef96e2c13
         x-checker-data:
           type: anitya
           project-id: 5387
@@ -72,7 +72,6 @@ modules:
           version-pattern: revision\s*=\s*([a-f0-9]+)
           url-template: https://github.com/nothings/stb/archive/$version/stb.tar.gz
 
-
       # Keep glm tracking https://github.com/ValveSoftware/gamescope/blob/master/subprojects/glm.wrap
       - type: archive
         url: https://github.com/g-truc/glm/archive/0af55ccecd98d4e5a8d1fad7de25ba429d60e863/glm.tar.gz
@@ -83,6 +82,8 @@ modules:
           url: https://raw.githubusercontent.com/ValveSoftware/gamescope/refs/heads/master/subprojects/glm.wrap
           version-pattern: revision\s*=\s*([a-f0-9]+)
           url-template: https://github.com/g-truc/glm/archive/$version/glm.tar.gz
+
+      # v4l-utils is a dependency of libdisplay-info tests
 
       - type: shell
         commands:
@@ -107,8 +108,8 @@ modules:
       - name: xmu
         sources:
           - type: archive
-            url: https://www.x.org/archive/individual/lib/libXmu-1.2.1.tar.xz
-            sha256: fcb27793248a39e5fcc5b9c4aec40cc0734b3ca76aac3d7d1c264e7f7e14e8b2
+            url: https://www.x.org/archive/individual/lib/libXmu-1.3.1.tar.xz
+            sha256: 81a99e94c4501e81c427cbaa4a11748b584933e94b7a156830c3621256857bc4
             x-checker-data:
               type: anitya
               project-id: 1785
@@ -120,7 +121,9 @@ modules:
           - /share
           - /lib/pkgconfig
 
+      # Used to build gamescope benchwarks
       - name: google-benchmark
+        disabled: true
         buildsystem: cmake-ninja
         config-opts:
           - -DBENCHMARK_ENABLE_GTEST_TESTS=OFF
@@ -128,8 +131,8 @@ modules:
           - -DCMAKE_CXX_FLAGS=
         sources:
           - type: archive
-            url: https://github.com/google/benchmark/archive/v1.9.4/google-benchmark-1.9.4.tar.gz
-            sha256: b334658edd35efcf06a99d9be21e4e93e092bd5f95074c1673d5c8705d95c104
+            url: https://github.com/google/benchmark/archive/v1.9.5/google-benchmark-1.9.5.tar.gz
+            sha256: 9631341c82bac4a288bef951f8b26b41f69021794184ece969f8473977eaa340
             x-checker-data:
               type: anitya
               project-id: 18299


### PR DESCRIPTION
seatd: Update 0.9.1 to 0.9.2
hwdata: Update 0.402 to 0.403
xmu: Update 1.2.1 to 1.3.1

Update shared-modules

Disable google-benchmark
Note that v4l-utils isn't needed