### PR TITLE
fedc: Disable flathubbot checker

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
+  "disable-external-data-checker": true,
   "skip-icons-check": true,
   "require-important-update": true
 }


### PR DESCRIPTION
I noticed some fedc MRs are from flathubbot and some from github-actions. I assume disabling fedc in flathub.json will make this more consistent.