### PR TITLE
ci: Disable fedc for 24.08, add 26.08

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        branch: [ branch/24.08, branch/25.08 ] # list all branches to check
+        branch: [ branch/25.08, branch/26.08 ] # list all branches to check
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
24.08 builds have started failing just in time for it to go EoL.